### PR TITLE
Reload on configuration change + enabling Slurm services on CentOS

### DIFF
--- a/src/reactive/slurm_node.py
+++ b/src/reactive/slurm_node.py
@@ -81,9 +81,11 @@ def configure_node(cluster_changed, cluster_joined):
     # Make sure munge is running
     if not service_running(MUNGE_SERVICE):
         service_start(MUNGE_SERVICE)
-    # Make sure slurmd is running
+    # Make sure slurmd is running, or restarted if running
     if not service_running(SLURMD_SERVICE):
         service_start(SLURMD_SERVICE)
+    else:
+        service_restart(SLURMD_SERVICE)
 
     flags.set_flag('slurm-node.configured')
     log('Set {} flag'.format('slurm-node.configured'))

--- a/src/reactive/slurm_node.py
+++ b/src/reactive/slurm_node.py
@@ -12,7 +12,7 @@ from charms.slurm.helpers import render_slurm_config
 
 from charmhelpers.core.host import service_stop
 from charmhelpers.core.host import service_pause
-from charmhelpers.core.host import service_start
+from charmhelpers.core.host import service_resume
 from charmhelpers.core.host import service_restart
 from charmhelpers.core.host import service_running
 from charmhelpers.core.hookenv import config
@@ -80,10 +80,10 @@ def configure_node(cluster_changed, cluster_joined):
 
     # Make sure munge is running
     if not service_running(MUNGE_SERVICE):
-        service_start(MUNGE_SERVICE)
+        service_resume(MUNGE_SERVICE)
     # Make sure slurmd is running, or restarted if running
     if not service_running(SLURMD_SERVICE):
-        service_start(SLURMD_SERVICE)
+        service_resume(SLURMD_SERVICE)
     else:
         service_restart(SLURMD_SERVICE)
 


### PR DESCRIPTION
Switched from service_start() to service_resume() for munge and slurmd
in configure_node(). This is a simple way of ensuring the services will
start on subsequent boots after the charm installation.

A Fedora/RHEL based distro will never have services enabled on
installation. Debian based distros typically do the opposite, but
letting charm enabling the services won't do any harm.

Making sure a running slurmd is restarted on configuration change
    
If slurmd isn't restarted, the node will not use the new configuration
received from the controller.