### PR TITLE
Add timelimit

### DIFF
--- a/src/config.yaml
+++ b/src/config.yaml
@@ -14,7 +14,7 @@ options:
     type: string
     default: 
     description: >-
-      'Timelimit set for jobs on the specified partiton. Default to no limit.'
+      'Timelimit set for jobs on the specified partiton in minutes. Default to no limit.'
   default:
     type: boolean
     default: False

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -10,6 +10,11 @@ options:
       in that partition record or replaced with a different set of default
       values. Each line where PartitionName is "DEFAULT" will replace or add to
       previous default values and not a reinitialize the default values.'
+  timelimit:
+    type: string
+    default: 
+    description: >-
+      'Timelimit set for jobs on the specified partiton. Default to no limit.'
   default:
     type: boolean
     default: False

--- a/src/reactive/slurm_node.py
+++ b/src/reactive/slurm_node.py
@@ -58,6 +58,7 @@ def send_node_info(cluster_endpoint):
     cluster_endpoint.send_node_info(hostname=hostname.split(".")[0],
                                     partition=config('partition'),
                                     default=config('default'),
+                                    timelimit=config('timelimit'),
                                     inventory=get_inventory())
     flags.set_flag('slurm-node.info.sent')
     log('Set {} flag'.format('slurm-node.info.sent'))


### PR DESCRIPTION
Slurm allows configuring timelimits for partitions. This PR implements that in the Juju gui. Accompanies PR in the https://github.com/omnivector-solutions/layer-slurm-controller repository.